### PR TITLE
Update ci.yml with 15 minute timeout for tests

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -62,6 +62,7 @@ jobs:
           bin/rails db:schema:load
           bin/rails db:migrate
       - name: Run tests
+        timeout-minutes: 15
         env:
           REDIS_URL: redis://localhost:6379/0
           RAILS_MASTER_KEY: ${{ secrets.master_key }}


### PR DESCRIPTION
By default Github Actions timeout after 6 hours, eating up all our spending limits ($30 so far this month). This changes timeout on tests step after 15 minutes instead:

![image](https://github.com/forsbergplustwo/github-actions/assets/1411883/087c8daa-3eea-4e3f-837a-9fc29005a377)

For some reason our tests are hanging forever at the moment, after Rails 7.1 upgrade.